### PR TITLE
 스킬 트리 편집시 발생하는 버그 수정

### DIFF
--- a/Assets/Script/System/EquippedSkillButtonController.cs
+++ b/Assets/Script/System/EquippedSkillButtonController.cs
@@ -10,10 +10,14 @@ public class EquippedSkillButtonController : MonoBehaviour
     private int skillGrade;
 
     private Image skillImage;
-    
-    private void Start()
+
+    private void Awake()
     {
         skillImage = GetComponent<Image>();
+    }
+
+    private void OnEnable()
+    {
         if (SkillSystemManager.Instance.equipSkillData[skillIndex] != null)
         {
             skillData = SkillSystemManager.Instance.equipSkillData[skillIndex];


### PR DESCRIPTION
1웨이브를 제외한 모든 웨이브에서 편집한 스킬트리가 장착 스킬 UI에 적용되지 않는 버그 수정
- 편집한 스킬트리가 장착 스킬 UI에 적용되는 코드의 위치를 옮겨서 해결함
- Start -> OnEnable

[![YouTube Thumbnail](https://img.youtube.com/vi/-vwtB8RmOSM/0.jpg)](https://www.youtube.com/watch?v=-vwtB8RmOSM)
